### PR TITLE
Set Quick pull down default to off

### DIFF
--- a/src/com/dirtyunicorns/dutweaks/fragments/QuickSettings.java
+++ b/src/com/dirtyunicorns/dutweaks/fragments/QuickSettings.java
@@ -96,7 +96,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
         mQuickPulldown = (ListPreference) findPreference(QUICK_PULLDOWN);
         mQuickPulldown.setOnPreferenceChangeListener(this);
         int quickPulldownValue = Settings.System.getIntForUser(getContentResolver(),
-                Settings.System.STATUS_BAR_QUICK_QS_PULLDOWN, 1, UserHandle.USER_CURRENT);
+                Settings.System.STATUS_BAR_QUICK_QS_PULLDOWN, 0, UserHandle.USER_CURRENT);
         mQuickPulldown.setValue(String.valueOf(quickPulldownValue));
         updatePulldownSummary(quickPulldownValue);
 


### PR DESCRIPTION
	-Quick pull down default was set to right, but had to be cyled to off then to right to make it work.
	 Might as well just make it default to off.

Change-Id: I3d1c4a4085b16ba0d1cb7ddecdba9986515c5fb6